### PR TITLE
Optionally create certificates just for subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ On unRaid, install from the Community Applications and enter the app folder loca
 
 On other platforms, you can run this docker with the following command:
 
-```docker run -d --privileged --name="Nginx-letsencrypt" -p 80:80 -p 443:443 -e EMAIL="youremail" -e URL="yourdomain.url" -e SUBDOMAINS="www,subdomain1,subdomain2" -v /path/to/config/:/config:rw -v /etc/localtime:/etc/localtime:ro aptalca/nginx-letsencrypt```
+```docker run -d --privileged --name="Nginx-letsencrypt" -p 80:80 -p 443:443 -e EMAIL="youremail" -e URL="yourdomain.url" -e SUBDOMAINS="www,subdomain1,subdomain2" -e ONLY_SUBDOMAINS="false" -v /path/to/config/:/config:rw -v /etc/localtime:/etc/localtime:ro aptalca/nginx-letsencrypt```
 
 - Replace the EMAIL variable (youremail) with the e-mail address you would like to register the SSL certificate with.
 - Replace the URL variable (yourdomain.url) with your server's internet domain name, without any subdomains (can also be a dynamic dns url, ie. google.com or username.duckdns.org).
 - Replace the SUBDOMAINS variable with your choice of subdomains (just the subdomains, comma separated, no spaces).
+- Replace the ONLY_SUBDOMAINS variable with "true" if you'd only like to generate SSL certificates for the listed subdomains.
 - Replace the "/path/to/config" with your choice of location.
 - Make sure that the port 443 in the container is accessible from the outside of your lan. It is OK to map container's port 443 to another port on the host (ie 943) as long as your router will forward port 443 from the outside to port 943 on the host and it will end up at port 443 in the container. If this is confusing, just leave the `-p 443:443` portion of the run command as is and forward port 443 on your router to your host IP.
 - Prior to SSL certificate creation, letsencrypt creates a temporary webserver and checks to see if it is accessible through the domain url provided for validation. Make sure that your server is reachable through your.domain.url:443 and that port 443 is forwarded on your router to the container's port 443 prior to running this docker. Otherwise letsencrypt validation will fail, and no certificates will be generated.

--- a/firstrun.sh
+++ b/firstrun.sh
@@ -72,16 +72,6 @@ ln -s /config/etc/letsencrypt /etc/letsencrypt
 rm /config/keys
 ln -s /config/etc/letsencrypt/live/"$URL" /config/keys
 
-if [ ! -z $SUBDOMAINS ]; then
-  echo "SUBDOMAINS entered, processing"
-  for job in $(echo $SUBDOMAINS | tr "," " "); do
-    export SUBDOMAINS2="$SUBDOMAINS2 -d "$job"."$URL""
-  done
-  echo "Sub-domains processed are:" $SUBDOMAINS2
-else
-  echo "No subdomains defined"
-fi
-
 if [ ! -f "/config/nginx/dhparams.pem" ]; then
   echo "Creating DH parameters for additional security. This may take a very long time. There will be another message once this process is completed"
   openssl dhparam -out /config/nginx/dhparams.pem 2048

--- a/firstrun.sh
+++ b/firstrun.sh
@@ -70,7 +70,13 @@ fi
 rm -r /etc/letsencrypt
 ln -s /config/etc/letsencrypt /etc/letsencrypt
 rm /config/keys
-ln -s /config/etc/letsencrypt/live/"$URL" /config/keys
+
+if [ "$ONLY_SUBDOMAINS" = true ]; then
+  SUBDOMAINURL="$(echo $SUBDOMAINS | tr ',' ' ' | awk '{print $1}')"."$URL"
+  ln -s /config/etc/letsencrypt/live/"$SUBDOMAINURL" /config/keys
+else
+  ln -s /config/etc/letsencrypt/live/"$URL" /config/keys
+fi
 
 if [ ! -f "/config/nginx/dhparams.pem" ]; then
   echo "Creating DH parameters for additional security. This may take a very long time. There will be another message once this process is completed"


### PR DESCRIPTION
Added an ONLY_SUBDOMAIN env variable that can be set to true, when only subdomain certificates are needed.
