### PR TITLE
Optional key strength

### DIFF
--- a/defaults/letsencrypt.sh
+++ b/defaults/letsencrypt.sh
@@ -26,7 +26,7 @@ fi
 echo "Temporarily stopping Nginx"
 service nginx stop
 echo "Generating/Renewing certificate"
-./letsencrypt-auto certonly --renew-by-default --standalone --standalone-supported-challenges tls-sni-01 --email $EMAIL --agree-tos -d $URL $SUBDOMAINS2
+./letsencrypt-auto certonly --renew-by-default --standalone --standalone-supported-challenges tls-sni-01  --rsa-key-size $STRENGTH --email $EMAIL --agree-tos -d $URL $SUBDOMAINS2
 chown -R nobody:users /config
 echo "Restarting web server"
 service nginx start

--- a/firstrun.sh
+++ b/firstrun.sh
@@ -86,7 +86,7 @@ fi
 
 if [ ! -f "/config/nginx/dhparams.pem" ]; then
   echo "Creating DH parameters for additional security. This may take a very long time. There will be another message once this process is completed"
-  openssl dhparam -out /config/nginx/dhparams.pem 2048
+  openssl dhparam -out /config/nginx/dhparams.pem $STRENGTH
   echo "DH parameters successfully created"
 else
   echo "Using existing DH parameters"


### PR DESCRIPTION
Please give us an option to reach 100/100 in https://www.ssllabs.com/ssltest little test.

(changes are untested)

$STRENGTH needs a default value (2048) set in the template.
